### PR TITLE
Update FormatEmoticons.php

### DIFF
--- a/src/Listener/FormatEmoticons.php
+++ b/src/Listener/FormatEmoticons.php
@@ -30,6 +30,7 @@ class FormatEmoticons
     public function addEmoticons(ConfigureFormatter $event)
     {
         $event->configurator->Emoji->useEmojiOne();
+        $event->configurator->Emoji->useSVG();
         $event->configurator->Emoji->omitImageSize();
 
         $event->configurator->Emoji->addAlias(':)', '🙂');


### PR DESCRIPTION
Change to use SVG emoticons instead PNG. This change adds all the advantages of use SVG files and solves the blurry downscaled images bug into Chrome discussed at https://github.com/flarum/core/pull/1276