### PR TITLE
Insert emoji character rather than shortcode

### DIFF
--- a/js/src/forum/addComposerAutocomplete.js
+++ b/js/src/forum/addComposerAutocomplete.js
@@ -22,7 +22,7 @@ export default function addComposerAutocomplete() {
     let typed;
 
     const applySuggestion = function(replacement) {
-      const insert = replacement + ' ';
+      const insert = String.fromCodePoint(...replacement.split('-').map(e => `0x${e}`)) + ' ';;
 
       const content = composer.content();
       composer.editor.setValue(content.substring(0, emojiStart - 1) + insert + content.substr($textarea[0].selectionStart));
@@ -81,7 +81,7 @@ export default function addComposerAutocomplete() {
             return (
               <button
                 key={key}
-                onclick={() => applySuggestion(code)}
+                onclick={() => applySuggestion(imageName)}
                 onmouseenter={function() {
                   dropdown.setIndex($(this).parent().index());
                 }}>


### PR DESCRIPTION
Requires the bootstrap.php changes from #16 for it to work or test it.
Closes flarum/core#1331.

`String.fromCodePoint` (ES6) uses ints to transform them into unicode characters, but automatically converts strings into numbers as well. It uses the image name, aka unicode string, and splits it & converts it, and then uses spread.
Output in Babel dist should be compatible with IE 
![image](https://user-images.githubusercontent.com/6401250/43011822-8d0de290-8c12-11e8-978c-b2bae7c584d4.png)

<details> 
  <summary>8MB GIF Preview</summary>
  <img src="https://user-images.githubusercontent.com/6401250/43012114-832771aa-8c13-11e8-9023-c69b5a6ae499.gif" />
</details>
